### PR TITLE
feat(processing): implement document processing for CSV and OFX files

### DIFF
--- a/src/handlers/bot_defs/handle_document.py
+++ b/src/handlers/bot_defs/handle_document.py
@@ -4,8 +4,122 @@ from telegram import Update
 from telegram.ext import ContextTypes
 from src.config.messages import TelegramMessages
 
+import os
+import json
+import tempfile
+from pathlib import Path
+from datetime import datetime
+import shutil
+
+from src.parsers.csv import parse_csv_bank_statement
+from src.parsers.ofx import parse_ofx_file
+from src.ai.transaction_classifier import categorize_with_gemini
+
 
 logger = get_logger(__name__)
+
+
+def _detect_file_type(file_name: str):
+  """Retorna 'csv' | 'ofx' ou None com base na extensão."""
+  lower = (file_name or "").lower()
+  if lower.endswith(".csv"):
+    return "csv"
+  if lower.endswith(".ofx"):
+    return "ofx"
+  return None
+
+
+async def _download_document_to_temp(context: ContextTypes.DEFAULT_TYPE, document, dest_dir: str) -> str:
+  """Baixa o arquivo do Telegram para um diretório temporário e retorna o caminho local."""
+  local_path = os.path.join(dest_dir, document.file_name or "arquivo")
+  tg_file = await context.bot.get_file(document.file_id)
+  await tg_file.download_to_drive(local_path)
+  logger.info(f"Arquivo baixado para {local_path}")
+  return local_path
+
+
+def _parse_file_to_statement(file_path: str, file_type: str):
+  """Parseia o arquivo (CSV/OFX) e retorna um ParsedBankStatement."""
+  if file_type == "csv":
+    return parse_csv_bank_statement(file_path)
+  if file_type == "ofx":
+    return parse_ofx_file(file_path)
+  raise ValueError(f"Tipo de arquivo não suportado: {file_type}")
+
+
+def _statement_to_transactions(statement) -> list:
+  """Converte ParsedBankStatement -> List[dict] esperado pelo classificador."""
+  return [
+    {
+      "id": expense.id,
+      "name": expense.name,
+      "value": float(expense.value),
+      "date": expense.date.isoformat(),
+    }
+    for expense in statement.expenses
+  ]
+
+
+def _categorize_with_ai(transactions: list) -> tuple:
+  """Tenta categorizar via Gemini. Retorna (transactions, ai_ok)."""
+  try:
+    categorized = categorize_with_gemini(transactions)
+    return categorized, True
+  except Exception as e:
+    logger.error(f"Falha ao categorizar com Gemini: {e}")
+    fallback = [
+      {
+        **tx,
+        "category": "Não categorizada",
+        "categorization_confidence": 0.0,
+        "categorization_reasoning": "AI indisponível",
+      }
+      for tx in transactions
+    ]
+    return fallback, False
+
+
+def _build_result_payload(file_name: str, file_type: str, categorized_transactions: list) -> dict:
+  """Monta o payload final de resultado para persistência/envio."""
+  return {
+    "original_file": file_name,
+    "processed_at": datetime.utcnow().isoformat() + "Z",
+    "file_type": file_type,
+    "total_transactions": len(categorized_transactions),
+    "transactions": categorized_transactions,
+  }
+
+
+def _write_result_json(dest_dir: str, file_stem: str, result: dict) -> str:
+  """Escreve o JSON de resultado e retorna o caminho gerado."""
+  result_path = os.path.join(dest_dir, f"{file_stem}_categorized.json")
+  with open(result_path, "w", encoding="utf-8") as f:
+    json.dump(result, f, ensure_ascii=False, indent=2)
+  return result_path
+
+
+def _is_debug_mode() -> bool:
+  """Determina se estamos em modo de debug via variáveis de ambiente.
+
+  Regras:
+  - Se DEBUG for verdadeiro (1/true/yes/on), considera debug.
+  - Caso contrário, se APP_ENV/ENVIRONMENT for 'production'/'prod', NÃO é debug.
+  - Demais ambientes são considerados debug por padrão.
+  """
+  debug_val = (os.getenv("DEBUG", "").strip().lower())
+  if debug_val in ("1", "true", "yes", "on"):
+    return True
+
+  env_val = (os.getenv("APP_ENV", os.getenv("ENVIRONMENT", "development")).strip().lower())
+  if env_val in ("production", "prod"):
+    return False
+
+  return True
+
+
+def _should_cleanup_tmp() -> bool:
+  """Remove arquivos temporários somente quando NÃO estiver em debug."""
+  return not _is_debug_mode()
 
 
 async def handle_document(update: Update, context: ContextTypes.DEFAULT_TYPE):
@@ -15,25 +129,67 @@ async def handle_document(update: Update, context: ContextTypes.DEFAULT_TYPE):
     await update.message.reply_text(TelegramMessages.INVALID_INPUT)
     return
   
-  file_name = document.file_name
+  file_name = document.file_name or "arquivo"
   user_id = update.message.from_user.id
 
   logger.info(f"Usuário {user_id} enviou o arquivo {file_name}")
 
-  if file_name.endswith(".csv"):
+  file_type = _detect_file_type(file_name)
+
+  if file_type in ("csv", "ofx"):
     await update.message.reply_text(
       TelegramMessages.RECEIVED_FILE.format(file_name=file_name)
-      + TelegramMessages.DETECTED_TYPE.format(file_type="CSV")
+      + TelegramMessages.DETECTED_TYPE.format(file_type=file_type.upper())
     )
 
-    # TODO: Implementar processamento de arquivo CSV
-  elif file_name.endswith(".ofx"):
-    await update.message.reply_text(
-      TelegramMessages.RECEIVED_FILE.format(file_name=file_name)
-      + TelegramMessages.DETECTED_TYPE.format(file_type="OFX")
-    )
+    # Cria diretório temporário e caminho local do arquivo
+    tmp_dir = tempfile.mkdtemp(prefix="fin-cat-")
 
-    # TODO: Implementar processamento de arquivo OFX
+    try:
+      # Baixa o arquivo recebido do Telegram
+      local_path = await _download_document_to_temp(context, document, tmp_dir)
+
+      # Faz o parse de acordo com o tipo
+      statement = _parse_file_to_statement(local_path, file_type)
+
+      # Converte para o formato esperado pelo AI
+      transactions = _statement_to_transactions(statement)
+
+      # Chama o classificador (Gemini)
+      categorized_transactions, ai_ok = _categorize_with_ai(transactions)
+
+      # Monta resultado e envia ao usuário
+      result = _build_result_payload(file_name, file_type, categorized_transactions)
+      result_path = _write_result_json(tmp_dir, Path(file_name).stem, result)
+
+      caption_lines = [
+        "✅ Processamento concluído!",
+        f"Transações: {len(categorized_transactions)}",
+      ]
+      if not ai_ok:
+        caption_lines.append("⚠️ Categorização por AI não disponível no momento.")
+
+      await update.message.reply_document(
+        document=open(result_path, "rb"),
+        filename=Path(result_path).name,
+        caption="\n".join(caption_lines),
+      )
+
+    except Exception as e:
+      logger.error(f"Erro ao processar arquivo '{file_name}': {e}")
+      await update.message.reply_text(
+        f"❌ Ocorreu um erro ao processar o arquivo: {str(e)}"
+      )
+    finally:
+      if _should_cleanup_tmp():
+        try:
+          shutil.rmtree(tmp_dir, ignore_errors=True)
+          logger.info(f"Diretório temporário removido: {tmp_dir}")
+        except Exception as cleanup_err:
+          logger.warning(f"Falha ao remover diretório temporário {tmp_dir}: {cleanup_err}")
+      else:
+        logger.info(f"Mantendo arquivos temporários para debug em: {tmp_dir}")
+
   else:
     await update.message.reply_text(
       TelegramMessages.UNSUPPORTED_FILE.format(file_name=file_name)


### PR DESCRIPTION
Added full processing flow for CSV and OFX bank statement files sent to the bot, including file type detection, download, parsing, AI-based transaction categorization, result packaging, and temporary file management. The handler now replies with a categorized JSON result or an error message, and cleans up temporary files unless in debug mode.

closes #15 and #16 